### PR TITLE
Output directory update

### DIFF
--- a/src/engine/engine.go
+++ b/src/engine/engine.go
@@ -25,7 +25,7 @@ func setBusy(_b bool) {
 
 // CleanExit Cleanly exits the simulation, assuring all output is flushed.
 func CleanExit() {
-	if outputdir == "" {
+	if OutputDir == "" {
 		return
 	}
 	drainOutput()

--- a/src/engine/od.go
+++ b/src/engine/od.go
@@ -12,8 +12,9 @@ import (
 )
 
 var (
-	outputdir string // Output directory
-	InputFile string
+	OutputDir       string // Output directory
+	InputFile       string
+	InputFileSuffix string
 
 	CacheDir       string
 	SkipExists     bool
@@ -24,16 +25,21 @@ var (
 )
 
 func OD() string {
-	if outputdir == "" {
+	if OutputDir == "" {
 		panic("output not yet initialized")
 	}
-	return outputdir
+	if !strings.HasSuffix(OutputDir, "/") {
+		return OutputDir + "/"
+	}
+	return OutputDir
 }
 
 // InitIO SetOD sets the output directory where auto-saved files will be stored.
 // The -o flag can also be used for this purpose.
 
 func InitIO(mx3Path, od, cachedir string, skipexists, forceclean, hideprogressbar, selftest, syncandlog bool) {
+	InputFile = mx3Path
+	InputFileSuffix = strings.TrimSuffix(mx3Path, ".mx3")
 	CacheDir = cachedir
 	SkipExists = skipexists
 	ForceClean = forceclean
@@ -41,30 +47,33 @@ func InitIO(mx3Path, od, cachedir string, skipexists, forceclean, hideprogressba
 	SelfTest = selftest
 	SyncAndLog = syncandlog
 
-	if outputdir != "" {
+	if OutputDir != "" {
 		panic("output directory already set")
 	}
-	InputFile = mx3Path
-	if !strings.HasSuffix(od, "/") {
-		od += "/"
-	}
-	outputdir = od
-	if strings.HasPrefix(outputdir, "http://") {
-		fsutil.SetWD(outputdir + "/../")
-	}
-	if fsutil.IsDir(od) {
-		// if directory exists and --skip-exist flag is set, skip the directory
-		if SkipExists {
-			log.Log.Warn("Directory `%s` exists, skipping `%s` because of --skip-exist flag.", od, mx3Path)
-			os.Exit(0)
-			// if directory exists and --force-clean flag is set, remove the directory
-		} else if ForceClean {
-			log.Log.Warn("Cleaning `%s`", od)
-			log.Log.PanicIfError(fsutil.Remove(od))
-			log.Log.PanicIfError(fsutil.Mkdir(od))
-		}
+
+	if od == "" {
+		OutputDir = InputFileSuffix + ".zarr"
 	} else {
-		log.Log.PanicIfError(fsutil.Mkdir(od))
+		OutputDir = od
+	}
+	if fsutil.IsDir(OutputDir) {
+		if SkipExists {
+			// if directory exists and --skip-exist flag is set, skip the directory
+			log.Log.Warn("Directory `%s` exists, skipping because of --skip-exist flag.", OutputDir)
+			os.Exit(0)
+		} else if ForceClean {
+			// if directory exists and --force-clean flag is set, remove the directory
+			log.Log.Warn("Cleaning `%s`", OutputDir)
+			log.Log.PanicIfError(fsutil.Remove(OutputDir))
+			log.Log.PanicIfError(fsutil.Mkdir(OutputDir))
+		} else if od != "" {
+			// If the -o directory exists and neither --skip-exist nor --force-clean flag is set, put the output InputFile.zarr in the -o directory
+			OutputDir = od + "/" + InputFileSuffix + ".zarr"
+			log.Log.Warn("Directory `%s` exists, putting output in `%s` because neither --skip-exist nor --force-clean flag is set.", od, OutputDir)
+		}
+	} else if !fsutil.Exists(OutputDir) {
+		// If the -o directory does not exist, create it in the plain -o directory.
+		log.Log.PanicIfError(fsutil.Mkdir(OutputDir))
 	}
 	zarr.InitZgroup("", OD())
 }

--- a/src/engine/od_test.go
+++ b/src/engine/od_test.go
@@ -1,0 +1,132 @@
+package engine
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/MathieuMoalic/amumax/src/fsutil"
+)
+
+func resetGlobals(t *testing.T) string {
+	tmpDir := t.TempDir()
+	OutputDir = ""
+	InputFile = ""
+	InputFileSuffix = ""
+	CacheDir = ""
+	SkipExists = false
+	ForceClean = false
+	HideProgresBar = false
+	SelfTest = false
+	SyncAndLog = false
+	fsutil.SetWD(tmpDir)
+
+	return tmpDir
+}
+
+func TestOD(t *testing.T) {
+	resetGlobals(t)
+
+	t.Run("Panic when not initialized", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("OD() should panic when OutputDir is empty")
+			}
+		}()
+		OD()
+	})
+
+	t.Run("Returns trailing slash", func(t *testing.T) {
+		OutputDir = "tmp/test"
+		res := OD()
+		if res != "tmp/test/" {
+			t.Errorf("Expected tmp/test/, got %s", res)
+		}
+	})
+
+	t.Run("Returns as is if already has slash", func(t *testing.T) {
+		OutputDir = "tmp/test/"
+		res := OD()
+		if res != "tmp/test/" {
+			t.Errorf("Expected tmp/test/, got %s", res)
+		}
+	})
+}
+
+func TestInitIO(t *testing.T) {
+	t.Run("Default output directory", func(t *testing.T) {
+		tmpDir := resetGlobals(t)
+		mx3 := "test_file.mx3"
+		InitIO(mx3, "", "", false, false, false, false, false)
+
+		expected := "test_file.zarr"
+		if OutputDir != expected {
+			t.Errorf("Expected OutputDir %s, got %s", expected, OutputDir)
+		}
+		if !fsutil.Exists(expected) {
+			t.Errorf("Expected directory %s to be created", expected)
+		}
+		fmt.Printf("\nTree for directory: %s\n", tmpDir)
+		fsutil.PrintTree(tmpDir, "")
+	})
+
+	t.Run("Custom output directory", func(t *testing.T) {
+		tmpDir := resetGlobals(t)
+		mx3 := "test_file.mx3"
+		customOD := "custom_out"
+		InitIO(mx3, customOD, "", false, false, false, false, false)
+
+		if OutputDir != customOD {
+			t.Errorf("Expected OutputDir %s, got %s", customOD, OutputDir)
+		}
+		if !fsutil.Exists(customOD) {
+			t.Errorf("Expected directory %s to be created", customOD)
+		}
+		fmt.Printf("\nTree for directory: %s\n", tmpDir)
+		fsutil.PrintTree(tmpDir, "")
+	})
+
+	t.Run("ForceClean wipes directory", func(t *testing.T) {
+		tmpDir := resetGlobals(t)
+		mx3 := "test_file.mx3"
+		od := "clean_me"
+
+		// Create directory and a file inside it
+		fsutil.Mkdir(od)
+		fsutil.Touch(od + "/somefile")
+
+		fmt.Printf("\nTree before calling InitIO for directory: %s\n", tmpDir)
+		fsutil.PrintTree(tmpDir, "")
+
+		InitIO(mx3, od, "", false, true, false, false, false)
+
+		if OutputDir != od {
+			t.Errorf("Expected OutputDir %s, got %s", od, OutputDir)
+		}
+		// Check if the file inside was removed
+		if fsutil.Exists(od + "/somefile") {
+			t.Errorf("Expected directory %s to be cleaned", od)
+		}
+		fmt.Printf("\nTree after calling InitIO for directory: %s\n", tmpDir)
+		fsutil.PrintTree(tmpDir, "")
+	})
+
+	t.Run("Existing directory nests output", func(t *testing.T) {
+		tmpDir := resetGlobals(t)
+		mx3 := "nest_test.mx3"
+		od := "nest_dir"
+
+		fsutil.Mkdir(od)
+
+		InitIO(mx3, od, "", false, false, false, false, false)
+
+		expected := od + "/" + "nest_test.zarr"
+		if OutputDir != expected {
+			t.Errorf("Expected OutputDir %s, got %s", expected, OutputDir)
+		}
+		if !fsutil.Exists(expected) {
+			t.Errorf("Expected nested directory %s to be created", expected)
+		}
+		fmt.Printf("\nTree for directory: %s\n", tmpDir)
+		fsutil.PrintTree(tmpDir, "")
+	})
+}

--- a/src/entrypoint/entrypoint.go
+++ b/src/entrypoint/entrypoint.go
@@ -6,7 +6,6 @@ import (
 	"fmt"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
@@ -144,9 +143,6 @@ func setupAndServe(flags *flags.Flags, mx3Path string, isInteractive bool) (*scr
 		}
 		inputPath = mx3Path
 		outputPath = flags.OutputDir
-		if outputPath == "" {
-			outputPath = strings.TrimSuffix(mx3Path, ".mx3") + ".zarr"
-		}
 		log.Log.Info("Input file: %s", mx3Path)
 	}
 

--- a/src/fsutil/fsutil.go
+++ b/src/fsutil/fsutil.go
@@ -169,6 +169,31 @@ func (w *bufWriter) Close() error {
 	return w.file.Close()
 }
 
+func PrintTree(path string, indent string) {
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		fmt.Printf("%s[Error reading %s: %v]\n", indent, path, err)
+		return
+	}
+
+	for i, entry := range entries {
+		prefix := "├── "
+		if i == len(entries)-1 {
+			prefix = "└── "
+		}
+		fmt.Printf("%s%s%s\n", indent, prefix, entry.Name())
+		if entry.IsDir() {
+			newIndent := indent
+			if i == len(entries)-1 {
+				newIndent += "    "
+			} else {
+				newIndent += "│   "
+			}
+			PrintTree(path+"/"+entry.Name(), newIndent)
+		}
+	}
+}
+
 // Helper function to add the working directory to the path if it's relative.
 func addWorkDir(p string) string {
 	if !filepath.IsAbs(p) {


### PR DESCRIPTION
In order to improve workflow ergonomy i present my suggestion on how i think the intuitive handling of -o flag should look like.

1. case: no -o flag is provided
expected: the output lands in current work directory with the same filename as the mx3 file but .zarr extension
example: 
```
cwd
    └── file.mx3
    └── file.zarr
        └── .zgroup
```
2. case: -o flag is set to nonexistent directory
expected: the directory is created and the .zgroup, .zarr etc. files are created directly in the directory provided in -o
example: 
```
cwd
    └── file.mx3
    └── outputs
        └── .zgroup
```
3.  case: -o flag is set to existent directory
expected: file.zarr is created in the directory provided in -o 
example: 
```
cwd
    └── file.mx3
    └── outputs
      └── file.zarr
          └── .zgroup
```

Tests output:
```
root@356d405c7365:/workspace# go test -v ./src/engine/...
=== RUN   TestOD
=== RUN   TestOD/Panic_when_not_initialized
=== RUN   TestOD/Returns_trailing_slash
=== RUN   TestOD/Returns_as_is_if_already_has_slash
--- PASS: TestOD (0.00s)
    --- PASS: TestOD/Panic_when_not_initialized (0.00s)
    --- PASS: TestOD/Returns_trailing_slash (0.00s)
    --- PASS: TestOD/Returns_as_is_if_already_has_slash (0.00s)
=== RUN   TestInitIO
=== RUN   TestInitIO/Default_output_directory

Tree for directory: /tmp/TestInitIODefault_output_directory1779689347/001
└── test_file.zarr
    └── .zgroup
=== RUN   TestInitIO/Custom_output_directory

Tree for directory: /tmp/TestInitIOCustom_output_directory1110480466/001
└── custom_out
    └── .zgroup
=== RUN   TestInitIO/ForceClean_wipes_directory

Tree before calling InitIO for directory: /tmp/TestInitIOForceClean_wipes_directory3543479690/001
└── clean_me
    └── somefile
// Cleaning `clean_me`

Tree after calling InitIO for directory: /tmp/TestInitIOForceClean_wipes_directory3543479690/001
└── clean_me
    └── .zgroup
=== RUN   TestInitIO/Existing_directory_nests_output
// Directory `nest_dir` exists, putting output in `nest_dir/nest_test.zarr` because neither --skip-exist nor --force-clean flag is set.

Tree for directory: /tmp/TestInitIOExisting_directory_nests_output1265906969/001
└── nest_dir
    └── nest_test.zarr
        └── .zgroup
--- PASS: TestInitIO (0.01s)
    --- PASS: TestInitIO/Default_output_directory (0.00s)
    --- PASS: TestInitIO/Custom_output_directory (0.00s)
    --- PASS: TestInitIO/ForceClean_wipes_directory (0.00s)
    --- PASS: TestInitIO/Existing_directory_nests_output (0.00s)
PASS
ok      github.com/MathieuMoalic/amumax/src/engine      0.015s
```